### PR TITLE
Improve checkout data integrity and UX

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -34,12 +34,11 @@ class CheckoutController extends Controller
         $data = $request->validate([
             'cliente_nombre'      => 'required|string|max:255',
             'cliente_telefono'    => 'required|string|max:20',
-            'cliente_direccion'   => 'required|string|max:255',
+            'cliente_direccion'   => 'nullable|string|max:255|required_if:metodo_entrega,delivery',
             'cliente_comentarios' => 'nullable|string',
             'metodo_entrega'      => 'required|in:pickup,delivery',
-            'zona_delivery'       => 'nullable|in:dentro,fuera',
-            'kms_fuera'           => 'nullable|integer|min:1',
-            'delivery_cost'       => 'required|integer|min:0',
+            'zona_delivery'       => 'nullable|string|in:dentro,fuera|required_if:metodo_entrega,delivery',
+            'kms_fuera'           => 'nullable|integer|min:1|required_if:zona_delivery,fuera',
         ]);
 
         $cart = $request->session()->get('cart', []);
@@ -47,20 +46,31 @@ class CheckoutController extends Controller
             return redirect()->route('cart.index');
         }
 
-        $subtotal     = collect($cart)->sum('total');
-        $deliveryCost = $data['delivery_cost'];
-        $total        = $subtotal + $deliveryCost;
+        $subtotal = collect($cart)->sum(fn ($item) => (float) ($item['total'] ?? 0));
+        $deliveryCost = $this->calculateDeliveryCost(
+            $data['metodo_entrega'],
+            $data['zona_delivery'] ?? null,
+            $data['kms_fuera'] ?? null
+        );
+        $total = $subtotal + $deliveryCost;
 
-        // Transacción para crear Order y OrderItems
-        DB::transaction(function () use ($data, $cart, $subtotal, $deliveryCost, $total, &$order) {
+        $kmsFuera = ($data['zona_delivery'] ?? null) === 'fuera'
+            ? (int) $data['kms_fuera']
+            : null;
+
+        $order = DB::transaction(function () use ($data, $cart, $subtotal, $deliveryCost, $total, $kmsFuera) {
             $order = Order::create([
                 'cliente_nombre'      => $data['cliente_nombre'],
                 'cliente_telefono'    => $data['cliente_telefono'],
-                'cliente_direccion'   => $data['cliente_direccion'],
+                'cliente_direccion'   => $data['metodo_entrega'] === 'delivery'
+                    ? $data['cliente_direccion']
+                    : null,
                 'cliente_comentarios' => $data['cliente_comentarios'] ?? null,
                 'metodo_entrega'      => $data['metodo_entrega'],
-                'zona_delivery'       => $data['zona_delivery'] ?? null,
-                'kms_fuera'           => $data['kms_fuera'] ?? null,
+                'zona_delivery'       => $data['metodo_entrega'] === 'delivery'
+                    ? ($data['zona_delivery'] ?? null)
+                    : null,
+                'kms_fuera'           => $kmsFuera,
                 'subtotal'            => $subtotal,
                 'delivery_cost'       => $deliveryCost,
                 'total'               => $total,
@@ -72,20 +82,29 @@ class CheckoutController extends Controller
                     'product_id'  => $item['producto_id'],
                     'nombre'      => $item['nombre'],
                     'unidades'    => $item['unidades'],
-                    'precio_unit' => $item['precio_unit'],
-                    'total'       => $item['total'],
-                    'detalle'     => json_encode($item['detalle']),
+                    'precio_unit' => (float) $item['precio_unit'],
+                    'total'       => (float) $item['total'],
+                    'detalle'     => $item['detalle'] ?? [],
                 ]);
             }
+
+            if (auth()->check()) {
+                $order->user()->associate(auth()->user());
+                $order->save();
+            }
+
+            return $order->fresh('items');
         });
 
         // Generar y guardar PDF de la boleta
+        $order->loadMissing('items');
+
         $pdf      = Pdf::loadView('pdf.invoice', compact('order'))
             ->setPaper('A4', 'portrait');
         $fileName = "boletas/boleta-{$order->id}.pdf";
         Storage::disk('public')->put($fileName, $pdf->output());
 
-        $order->user_id = auth()->id();
+        $request->session()->forget('cart');
 
         // Redirigir a Mercado Pago
         try {
@@ -95,6 +114,22 @@ class CheckoutController extends Controller
             report($e);
             return back()->withErrors('No pudimos conectar con Mercado Pago. Intenta nuevamente.');
         }
+    }
+
+    private function calculateDeliveryCost(string $method, ?string $zone, $kms): float
+    {
+        if ($method !== 'delivery') {
+            return 0.0;
+        }
+
+        $baseCost = 2500;
+
+        if ($zone === 'fuera') {
+            $distance = max(1, (int) $kms);
+            return $baseCost + ($distance * 500);
+        }
+
+        return $baseCost;
     }
 
     /* =========================================================

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -42,10 +42,9 @@ class ProfileController extends Controller
             $user->avatar = $path;
         }
 
-        $user->fill(collect($validated)->except('password')->toArray());
+        $user->fill(collect($validated)->except(['password', 'avatar'])->toArray());
 
-
-        if ($validated['password']) {
+        if (! empty($validated['password'] ?? null)) {
             $user->password = Hash::make($validated['password']);
         }
 

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 
 class Order extends Model
@@ -8,13 +9,38 @@ class Order extends Model
     protected $fillable = [
         'cliente_nombre',
         'cliente_telefono',
-        'comentarios',
+        'cliente_direccion',
+        'cliente_comentarios',
+        'metodo_entrega',
+        'zona_delivery',
+        'kms_fuera',
+        'subtotal',
+        'delivery_cost',
         'total',
         'status',
     ];
 
+    protected $casts = [
+        'subtotal'      => 'decimal:2',
+        'delivery_cost' => 'decimal:2',
+        'total'         => 'decimal:2',
+        'kms_fuera'     => 'integer',
+    ];
+
+    protected $appends = ['envio'];
+
     public function items()
     {
         return $this->hasMany(OrderItem::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    protected function envio(): Attribute
+    {
+        return Attribute::get(fn () => $this->delivery_cost ?? 0);
     }
 }

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -19,6 +19,9 @@ class OrderItem extends Model
     protected $casts = [
         'removed_bases' => 'array',
         'extras'        => 'array',
+        'detalle'       => 'array',
+        'precio_unit'   => 'decimal:2',
+        'total'         => 'decimal:2',
     ];
 
     public function producto()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,7 +13,10 @@ class User extends Authenticatable
     protected $fillable = [
         'name',
         'email',
-        'password',
+        'phone',
+        'address',
+        'birthdate',
+        'avatar',
         'is_admin',       // <-- añadir
     ];
 
@@ -27,6 +30,7 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password'          => 'hashed',
         'is_admin'          => 'boolean',  // <-- añadir
+        'birthdate'         => 'date',
     ];
 
     /**

--- a/app/Services/MercadoPagoService.php
+++ b/app/Services/MercadoPagoService.php
@@ -32,9 +32,23 @@ class MercadoPagoService
      */
     public function createPreference(Order $order): string
     {
-        // ... tu código para armar $items, back_urls, etc. ...
+        $order->loadMissing('items');
 
-        $preference = $this->client->create([
+        $items = $order->items->map(function ($item) {
+            return [
+                'id'          => (string) $item->product_id,
+                'title'       => $item->nombre,
+                'quantity'    => (int) $item->unidades,
+                'unit_price'  => (float) $item->precio_unit,
+                'currency_id' => 'CLP',
+            ];
+        })->values()->all();
+
+        if (empty($items)) {
+            throw new \RuntimeException('No se pudieron generar los items para Mercado Pago.');
+        }
+
+        $payload = [
             'items'              => $items,
             'external_reference' => (string) $order->id,
             'payer'              => [
@@ -48,7 +62,23 @@ class MercadoPagoService
             ],
             'auto_return'      => 'approved',
             'notification_url' => route('checkout.webhook'),
-        ]);
+            'statement_descriptor' => 'Sushi Akila',
+        ];
+
+        if ($order->metodo_entrega === 'delivery') {
+            $payload['shipments'] = [
+                'receiver_address' => array_filter([
+                    'street_name' => $order->cliente_direccion,
+                    'zip_code'    => '0',
+                    'city_name'   => 'San José',
+                    'state_name'  => 'Costa Rica',
+                ], fn ($value) => !is_null($value) && $value !== ''),
+                'cost' => (float) $order->delivery_cost,
+                'mode' => 'not_specified',
+            ];
+        }
+
+        $preference = $this->client->create($payload);
 
         return app()->environment('production')
             ? $preference->init_point

--- a/database/migrations/2025_05_12_144710_create_orders_table.php
+++ b/database/migrations/2025_05_12_144710_create_orders_table.php
@@ -27,6 +27,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('=orders');
+        Schema::dropIfExists('orders');
     }
 };

--- a/database/migrations/2025_05_27_000000_update_orders_checkout_fields.php
+++ b/database/migrations/2025_05_27_000000_update_orders_checkout_fields.php
@@ -1,0 +1,90 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('orders', 'comentarios')) {
+            Schema::table('orders', function (Blueprint $table) {
+                $table->renameColumn('comentarios', 'cliente_comentarios');
+            });
+        }
+
+        Schema::table('orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('orders', 'cliente_direccion')) {
+                $table->string('cliente_direccion')
+                    ->nullable()
+                    ->after('cliente_telefono');
+            }
+
+            if (! Schema::hasColumn('orders', 'metodo_entrega')) {
+                $table->string('metodo_entrega', 20)
+                    ->default('pickup')
+                    ->after('cliente_direccion');
+            }
+
+            if (! Schema::hasColumn('orders', 'zona_delivery')) {
+                $table->string('zona_delivery', 20)
+                    ->nullable()
+                    ->after('metodo_entrega');
+            }
+
+            if (! Schema::hasColumn('orders', 'kms_fuera')) {
+                $table->unsignedSmallInteger('kms_fuera')
+                    ->nullable()
+                    ->after('zona_delivery');
+            }
+
+            if (! Schema::hasColumn('orders', 'subtotal')) {
+                $table->decimal('subtotal', 10, 2)
+                    ->default(0)
+                    ->after('kms_fuera');
+            }
+
+            if (! Schema::hasColumn('orders', 'delivery_cost')) {
+                $table->decimal('delivery_cost', 10, 2)
+                    ->default(0)
+                    ->after('subtotal');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (Schema::hasColumn('orders', 'delivery_cost')) {
+                $table->dropColumn('delivery_cost');
+            }
+
+            if (Schema::hasColumn('orders', 'subtotal')) {
+                $table->dropColumn('subtotal');
+            }
+
+            if (Schema::hasColumn('orders', 'kms_fuera')) {
+                $table->dropColumn('kms_fuera');
+            }
+
+            if (Schema::hasColumn('orders', 'zona_delivery')) {
+                $table->dropColumn('zona_delivery');
+            }
+
+            if (Schema::hasColumn('orders', 'metodo_entrega')) {
+                $table->dropColumn('metodo_entrega');
+            }
+
+            if (Schema::hasColumn('orders', 'cliente_direccion')) {
+                $table->dropColumn('cliente_direccion');
+            }
+        });
+
+        if (Schema::hasColumn('orders', 'cliente_comentarios')) {
+            Schema::table('orders', function (Blueprint $table) {
+                $table->renameColumn('cliente_comentarios', 'comentarios');
+            });
+        }
+    }
+};

--- a/database/migrations/2025_05_27_000100_adjust_order_items_amount_precision.php
+++ b/database/migrations/2025_05_27_000100_adjust_order_items_amount_precision.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $connection = Schema::getConnection()->getDriverName();
+
+        if ($connection === 'sqlite') {
+            Schema::table('order_items', function (Blueprint $table) {
+                $table->decimal('precio_unit_tmp', 10, 2)->nullable()->after('unidades');
+                $table->decimal('total_tmp', 10, 2)->nullable()->after('precio_unit_tmp');
+            });
+
+            DB::table('order_items')->update([
+                'precio_unit_tmp' => DB::raw('precio_unit'),
+                'total_tmp'       => DB::raw('total'),
+            ]);
+
+            Schema::table('order_items', function (Blueprint $table) {
+                $table->dropColumn(['precio_unit', 'total']);
+            });
+
+            Schema::table('order_items', function (Blueprint $table) {
+                $table->renameColumn('precio_unit_tmp', 'precio_unit');
+                $table->renameColumn('total_tmp', 'total');
+            });
+
+            return;
+        }
+
+        DB::statement('ALTER TABLE order_items MODIFY COLUMN precio_unit DECIMAL(10,2)');
+        DB::statement('ALTER TABLE order_items MODIFY COLUMN total DECIMAL(10,2)');
+    }
+
+    public function down(): void
+    {
+        $connection = Schema::getConnection()->getDriverName();
+
+        if ($connection === 'sqlite') {
+            Schema::table('order_items', function (Blueprint $table) {
+                $table->decimal('precio_unit_tmp', 10, 0)->nullable()->after('unidades');
+                $table->decimal('total_tmp', 10, 0)->nullable()->after('precio_unit_tmp');
+            });
+
+            DB::table('order_items')->update([
+                'precio_unit_tmp' => DB::raw('precio_unit'),
+                'total_tmp'       => DB::raw('total'),
+            ]);
+
+            Schema::table('order_items', function (Blueprint $table) {
+                $table->dropColumn(['precio_unit', 'total']);
+            });
+
+            Schema::table('order_items', function (Blueprint $table) {
+                $table->renameColumn('precio_unit_tmp', 'precio_unit');
+                $table->renameColumn('total_tmp', 'total');
+            });
+
+            return;
+        }
+
+        DB::statement('ALTER TABLE order_items MODIFY COLUMN precio_unit DECIMAL(10,0)');
+        DB::statement('ALTER TABLE order_items MODIFY COLUMN total DECIMAL(10,0)');
+    }
+};

--- a/resources/views/checkout/index.blade.php
+++ b/resources/views/checkout/index.blade.php
@@ -8,8 +8,8 @@
         $subtotal = collect($cart)->sum('total');
     @endphp
 
-    <div class="container mx-auto p-6 max-w-lg">
-        <h2 class="text-2xl font-bold mb-4">Finalizar Compra</h2>
+    <div class="container mx-auto p-6 max-w-3xl">
+        <h2 class="text-3xl font-bold mb-6 text-center">Finaliza tu pedido</h2>
 
         {{-- Errores --}}
         @if ($errors->any())
@@ -23,118 +23,130 @@
         @endif
 
         {{-- Resumen carrito --}}
-        <div class="mb-6">
-            <h3 class="font-semibold mb-2">Tu pedido</h3>
+        <div class="mb-8 grid gap-4 lg:grid-cols-2">
+            <div class="bg-white shadow rounded-lg p-5 border border-slate-100">
+                <h3 class="font-semibold text-lg mb-3">Tu pedido</h3>
 
-            @foreach ($cart as $item)
-                @php
-                    $d = $item['detalle'];
-                    $itemSubtotal = $item['precio_unit'] * $item['unidades'];
+                @foreach ($cart as $item)
+                    @php
+                        $d = $item['detalle'];
+                        $itemSubtotal = $item['precio_unit'] * $item['unidades'];
 
-                    // Agrupar proteínas
-                    $proteCounts = collect($d['Proteínas'] ?? [])
-                        ->countBy()
-                        ->map(fn($qty, $name) => "{$qty} de {$name}")
-                        ->values()
-                        ->all();
+                        // Agrupar proteínas
+                        $proteCounts = collect($d['Proteínas'] ?? [])
+                            ->countBy()
+                            ->map(fn ($qty, $name) => "{$qty} de {$name}")
+                            ->values()
+                            ->all();
 
-                    // Agrupar vegetales
-                    $vegCounts = collect($d['Vegetales'] ?? [])
-                        ->countBy()
-                        ->map(fn($qty, $name) => "{$qty} de {$name}")
-                        ->values()
-                        ->all();
-                @endphp
+                        // Agrupar vegetales
+                        $vegCounts = collect($d['Vegetales'] ?? [])
+                            ->countBy()
+                            ->map(fn ($qty, $name) => "{$qty} de {$name}")
+                            ->values()
+                            ->all();
+                    @endphp
 
-                <div class="border rounded p-3 mb-3">
-                    <p class="font-semibold">
-                        {{ $item['nombre'] }}
-                        <span class="text-gray-500">×{{ $item['unidades'] }}</span>
-                    </p>
+                    <div class="border rounded p-3 mb-3 bg-slate-50">
+                        <p class="font-semibold">
+                            {{ $item['nombre'] }}
+                            <span class="text-gray-500">×{{ $item['unidades'] }}</span>
+                        </p>
 
-                    <ul class="text-xs text-gray-700 space-y-1 mt-1">
-                        <li>
-                            <strong>Base:</strong>
-                            {{ $d['Base'] ?? '—' }}
-                        </li>
-                        <li>
-                            <strong>Proteínas:</strong>
-                            {{ $proteCounts ? implode(', ', $proteCounts) : '—' }}
-                        </li>
-                        <li>
-                            <strong>Vegetales:</strong>
-                            {{ $vegCounts ? implode(', ', $vegCounts) : '—' }}
-                        </li>
-                        @if ($d['Sin queso'] ?? false)
-                            <li class="text-amber-700">Sin queso crema</li>
-                        @endif
-                        @if ($d['Sin cebollín'] ?? false)
-                            <li class="text-amber-700">Sin cebollín</li>
-                        @endif
-                    </ul>
+                        <ul class="text-xs text-gray-700 space-y-1 mt-1">
+                            <li>
+                                <strong>Base:</strong>
+                                {{ $d['Base'] ?? '—' }}
+                            </li>
+                            <li>
+                                <strong>Proteínas:</strong>
+                                {{ $proteCounts ? implode(', ', $proteCounts) : '—' }}
+                            </li>
+                            <li>
+                                <strong>Vegetales:</strong>
+                                {{ $vegCounts ? implode(', ', $vegCounts) : '—' }}
+                            </li>
+                            @if ($d['Sin queso'] ?? false)
+                                <li class="text-amber-700">Sin queso crema</li>
+                            @endif
+                            @if ($d['Sin cebollín'] ?? false)
+                                <li class="text-amber-700">Sin cebollín</li>
+                            @endif
+                        </ul>
 
-                    <p class="text-sm text-gray-600 mt-1">
-                        Subtotal: ${{ number_format($itemSubtotal, 0, ',', '.') }}
-                    </p>
-                </div>
-            @endforeach
-        </div>
+                        <p class="text-sm text-gray-600 mt-1">
+                            Subtotal: ${{ number_format($itemSubtotal, 2, ',', '.') }}
+                        </p>
+                    </div>
+                @endforeach
+            </div>
 
-        {{-- === FORM === --}}
-        <form id="checkoutForm" action="{{ route('checkout.store') }}" method="POST" class="space-y-6">
-            @csrf
+            {{-- === FORM === --}}
+            <form id="checkoutForm" action="{{ route('checkout.store') }}" method="POST"
+                class="space-y-6 bg-white shadow rounded-lg p-5 border border-slate-100">
+                @csrf
 
             {{-- Opciones de entrega --}}
             <div>
                 <h3 class="font-semibold mb-2">Método de entrega</h3>
 
-                <label class="inline-flex items-center gap-2 mb-2">
-                    <input type="radio" name="metodo_entrega" value="pickup" class="form-radio" checked
-                        onclick="updateDelivery()">
-                    Retiro en tienda (sin costo)
-                </label><br>
+                <div class="flex flex-col gap-2">
+                    <label class="inline-flex items-center gap-2">
+                        <input type="radio" name="metodo_entrega" value="pickup" class="text-green-600"
+                            checked onclick="updateDelivery()">
+                        <span>
+                            <span class="font-medium">Retiro en tienda</span>
+                            <span class="block text-xs text-gray-500">Sin costo adicional</span>
+                        </span>
+                    </label>
 
-                <label class="inline-flex items-center gap-2">
-                    <input type="radio" name="metodo_entrega" value="delivery" class="form-radio"
-                        onclick="updateDelivery()">
-                    Delivery
-                </label>
+                    <label class="inline-flex items-center gap-2">
+                        <input type="radio" name="metodo_entrega" value="delivery" class="text-green-600"
+                            onclick="updateDelivery()">
+                        <span>
+                            <span class="font-medium">Delivery a domicilio</span>
+                            <span class="block text-xs text-gray-500">Base $2.500 + $500 por km fuera de San José</span>
+                        </span>
+                    </label>
+                </div>
 
                 {{-- Opciones de delivery --}}
-                <div id="deliveryOptions" class="mt-4 ml-6 hidden space-y-3">
+                <div id="deliveryOptions" class="mt-4 ml-1 hidden space-y-3">
+                    <p class="text-sm text-gray-600">Selecciona tu zona:</p>
                     <label class="inline-flex items-center gap-2">
-                        <input type="radio" name="zona_delivery" value="dentro" class="form-radio"
+                        <input type="radio" name="zona_delivery" value="dentro" class="text-green-600"
                             onclick="updateDelivery()">
                         Dentro de San José (+$2.500)
-                    </label><br>
+                    </label>
 
                     <label class="inline-flex items-center gap-2">
-                        <input type="radio" name="zona_delivery" value="fuera" class="form-radio"
+                        <input type="radio" name="zona_delivery" value="fuera" class="text-green-600"
                             onclick="updateDelivery()">
                         Fuera de San José
                     </label>
 
                     {{-- Km input --}}
                     <div id="kmBox" class="mt-2 ml-6 hidden">
-                        <label for="kms_fuera" class="text-sm">Kms aproximados desde San José:</label>
-                        <input type="number" name="kms_fuera" id="kms_fuera" min="1" value="1"
-                            class="border p-1 w-20 ml-2" oninput="updateDelivery()">
-                        <p class="text-xs text-gray-500 mt-1">Recargo: $2.500 + $500 por km</p>
+                        <label for="kms_fuera" class="text-sm font-medium">Kms aproximados desde San José</label>
+                        <div class="flex items-center gap-3 mt-1">
+                            <input type="number" name="kms_fuera" id="kms_fuera" min="1" value="1"
+                                class="border p-1 w-24 rounded" oninput="updateDelivery()">
+                            <span class="text-xs text-gray-500">Recargo: $2.500 + $500 por km</span>
+                        </div>
                     </div>
                 </div>
             </div>
 
             {{-- Totales dinámicos --}}
-            <div class="border-t pt-4">
-                <p class="text-right font-semibold">
-                    Subtotal: ${{ number_format($subtotal, 0, ',', '.') }}
+            <div class="border-t pt-4 space-y-1 text-right bg-slate-50 rounded p-4">
+                <p class="font-semibold text-slate-600">
+                    Subtotal: <span id="subtotalAmount">${{ number_format($subtotal, 2, ',', '.') }}</span>
                 </p>
-                <p id="deliveryLine" class="text-right font-semibold hidden">
-                    Delivery: $<span id="deliveryCost">0</span>
+                <p id="deliveryLine" class="font-semibold text-slate-600 hidden">
+                    Delivery: <span id="deliveryCost">$0</span>
                 </p>
-                <p class="text-right text-lg font-bold">
-                    Total a pagar: $
-                    <span id="totalPay">{{ number_format($subtotal, 0, ',', '.') }}</span>
+                <p class="text-xl font-bold text-slate-900">
+                    Total a pagar: <span id="totalPay">${{ number_format($subtotal, 2, ',', '.') }}</span>
                 </p>
             </div>
 
@@ -152,11 +164,12 @@
                         value="{{ old('cliente_telefono') }}" class="border p-2 w-full" required>
                 </div>
 
-                <div>
+                <div id="addressGroup" class="hidden">
                     <label for="cliente_direccion" class="block font-medium">Dirección de entrega:</label>
                     <input type="text" id="cliente_direccion" name="cliente_direccion"
                         value="{{ old('cliente_direccion') }}" placeholder="Calle, número, referencia…"
-                        class="border p-2 w-full" required>
+                        class="border p-2 w-full">
+                    <p class="text-xs text-gray-500 mt-1">Solo solicitamos dirección cuando seleccionas delivery.</p>
                 </div>
 
                 <div>
@@ -165,13 +178,11 @@
                 </div>
             </div>
 
-            {{-- Hidden delivery cost para backend --}}
-            <input type="hidden" name="delivery_cost" id="delivery_cost" value="0">
-
             <button type="submit" class="w-full bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">
                 Confirmar Pedido
             </button>
         </form>
+        </div>
     </div>
 
     @push('scripts')
@@ -188,7 +199,8 @@
             const deliveryLine = document.getElementById('deliveryLine');
             const deliveryCostEl = document.getElementById('deliveryCost');
             const totalPayEl = document.getElementById('totalPay');
-            const hiddenCost = document.getElementById('delivery_cost');
+            const addressGroup = document.getElementById('addressGroup');
+            const addressInput = document.getElementById('cliente_direccion');
 
             function updateDelivery() {
                 const metodo = document.querySelector('input[name="metodo_entrega"]:checked').value;
@@ -196,6 +208,9 @@
 
                 if (metodo === 'delivery') {
                     deliveryOptions.classList.remove('hidden');
+                    addressGroup.classList.remove('hidden');
+                    addressInput.removeAttribute('disabled');
+                    addressInput.setAttribute('required', 'required');
                     const zona = document.querySelector('input[name="zona_delivery"]:checked');
                     if (zona) {
                         if (zona.value === 'dentro') {
@@ -210,12 +225,26 @@
                 } else {
                     deliveryOptions.classList.add('hidden');
                     kmBox.classList.add('hidden');
+                    addressGroup.classList.add('hidden');
+                    addressInput.value = '';
+                    addressInput.setAttribute('disabled', 'disabled');
+                    addressInput.removeAttribute('required');
+                    const selectedZone = document.querySelector('input[name="zona_delivery"]:checked');
+                    if (selectedZone) {
+                        selectedZone.checked = false;
+                    }
                 }
 
                 deliveryLine.classList.toggle('hidden', cost === 0);
-                deliveryCostEl.textContent = cost.toLocaleString('de-DE');
-                totalPayEl.textContent = (SUBTOTAL + cost).toLocaleString('de-DE');
-                hiddenCost.value = cost;
+                deliveryCostEl.textContent = formatCurrency(cost);
+                totalPayEl.textContent = formatCurrency(SUBTOTAL + cost);
+            }
+
+            function formatCurrency(value) {
+                return `$${Number(value).toLocaleString('es-CL', {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
+                })}`;
             }
 
             // Inicializa

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -65,6 +65,22 @@
                 <td><strong>Cliente:</strong> {{ $order->cliente_nombre }}</td>
                 <td><strong>Teléfono:</strong> {{ $order->cliente_telefono }}</td>
             </tr>
+            <tr>
+                <td><strong>Método:</strong>
+                    {{ $order->metodo_entrega === 'delivery' ? 'Delivery' : 'Retiro en tienda' }}</td>
+                <td><strong>Zona:</strong>
+                    @if ($order->metodo_entrega === 'delivery')
+                        {{ $order->zona_delivery === 'fuera' ? 'Fuera de San José' : 'Dentro de San José' }}
+                    @else
+                        —
+                    @endif
+                </td>
+            </tr>
+            @if ($order->metodo_entrega === 'delivery' && $order->kms_fuera)
+                <tr>
+                    <td colspan="2"><strong>Kms extra:</strong> {{ $order->kms_fuera }} km</td>
+                </tr>
+            @endif
             @if ($order->cliente_direccion)
                 <tr>
                     <td colspan="2"><strong>Dirección:</strong> {{ $order->cliente_direccion }}</td>
@@ -92,26 +108,26 @@
         </thead>
         <tbody>
             @foreach ($order->items as $item)
-                @php($d = json_decode($item->detalle, true))
+                @php($d = collect($item->detalle ?? []))
                 <tr>
                     <td>{{ $item->nombre }}</td>
                     <td class="right">{{ $item->unidades }}</td>
-                    <td class="right">${{ number_format($item->precio_unit, 0, ',', '.') }}</td>
+                    <td class="right">${{ number_format($item->precio_unit, 2, ',', '.') }}</td>
                     <td>
-                        <div class="small"><strong>Base:</strong> {{ $d['Base'] ?? '—' }}</div>
+                        <div class="small"><strong>Base:</strong> {{ $d->get('Base', '—') }}</div>
                         <div class="small"><strong>Proteínas:</strong>
-                            {{ collect($d['Proteínas'] ?? [])->join(', ') ?: '—' }}</div>
+                            {{ collect($d->get('Proteínas', []))->join(', ') ?: '—' }}</div>
                         <div class="small"><strong>Vegetales:</strong>
-                            {{ collect($d['Vegetales'] ?? [])->join(', ') ?: '—' }}</div>
-                        @if ($d['Sin queso'] ?? false)
+                            {{ collect($d->get('Vegetales', []))->join(', ') ?: '—' }}</div>
+                        @if ($d->get('Sin queso'))
                             <div class="small">Sin queso crema</div>
                         @endif
-                        @if ($d['Sin cebollín'] ?? false)
+                        @if ($d->get('Sin cebollín'))
                             <div class="small">Sin cebollín</div>
                         @endif
                     </td>
                     <td class="right font-bold">
-                        ${{ number_format($item->total, 0, ',', '.') }}
+                        ${{ number_format($item->total, 2, ',', '.') }}
                     </td>
                 </tr>
             @endforeach
@@ -123,17 +139,17 @@
         <tbody>
             <tr>
                 <td><strong>Subtotal:</strong></td>
-                <td class="right">${{ number_format($order->subtotal, 0, ',', '.') }}</td>
+                <td class="right">${{ number_format($order->subtotal, 2, ',', '.') }}</td>
             </tr>
             @if (($order->envio ?? 0) > 0)
                 <tr>
                     <td><strong>Envío:</strong></td>
-                    <td class="right">${{ number_format($order->envio, 0, ',', '.') }}</td>
+                    <td class="right">${{ number_format($order->envio, 2, ',', '.') }}</td>
                 </tr>
             @endif
             <tr>
                 <td><strong>Total:</strong></td>
-                <td class="right">${{ number_format($order->total, 0, ',', '.') }}</td>
+                <td class="right">${{ number_format($order->total, 2, ',', '.') }}</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- align the orders schema and model with the checkout flow, including delivery metadata and decimal totals
- harden the checkout controller, view and Mercado Pago integration to calculate delivery costs server-side and generate valid payment preferences
- allow profile updates to persist optional fields and refresh the PDF invoice styling with the richer order data

## Testing
- php -l app/Http/Controllers/CheckoutController.php
- php -l database/migrations/2025_05_27_000000_update_orders_checkout_fields.php
- php -l database/migrations/2025_05_27_000100_adjust_order_items_amount_precision.php

------
https://chatgpt.com/codex/tasks/task_e_68dfd44ae07883238c9b81b9b963d357