### PR TITLE
Fix MercadoPago runtime environment configuration

### DIFF
--- a/app/Services/MercadoPagoService.php
+++ b/app/Services/MercadoPagoService.php
@@ -19,9 +19,11 @@ class MercadoPagoService
 
         // 2) Para pruebas locales, desactiva la verificación SSL
         //    (usa HTTP interno o skip de SSL)
-        MercadoPagoConfig::setRuntimeEnviroment(
-            MercadoPagoConfig::LOCAL
-        );  // :contentReference[oaicite:0]{index=0}
+        if (app()->environment('local')) {
+            MercadoPagoConfig::setRuntimeEnvironment(
+                MercadoPagoConfig::LOCAL
+            );  // :contentReference[oaicite:0]{index=0}
+        }
 
         // 3) Instancia el client
         $this->client = new PreferenceClient();


### PR DESCRIPTION
## Summary
- correct the MercadoPago runtime configuration call to use the proper method
- only override the MercadoPago runtime environment when running locally

## Testing
- php -l app/Services/MercadoPagoService.php

------
https://chatgpt.com/codex/tasks/task_e_68dfe14694408323bedd7e8ba7d1e8ea