### PR TITLE
Add Mercado Pago payment id tracking

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -18,6 +18,7 @@ class Order extends Model
         'delivery_cost',
         'total',
         'status',
+        'mp_payment_id',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_10_03_144455_add_mp_payment_id_to_orders.php
+++ b/database/migrations/2025_10_03_144455_add_mp_payment_id_to_orders.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->string('mp_payment_id')->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn('mp_payment_id');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a nullable `mp_payment_id` column to the orders table
- allow orders to store the Mercado Pago payment identifier when updating from the controller

## Testing
- php artisan migrate

------
https://chatgpt.com/codex/tasks/task_e_68dfe14903e88323b9247aecb13ebbc8